### PR TITLE
Fix: Updating boredapi.com to bored-api.appbrewery.com

### DIFF
--- a/src/main/java/edu/brown/cs/student/main/server/ActivityHandler.java
+++ b/src/main/java/edu/brown/cs/student/main/server/ActivityHandler.java
@@ -20,7 +20,7 @@ import spark.Route;
  * will also demonstrate a simple Moshi deserialization from online data.
  */
 // TODO 1: Check out this Handler. How can we make it only get activities based on participant #?
-// See Documentation here: https://www.boredapi.com/documentation
+// See Documentation here: https://bored-api.appbrewery.com/
 public class ActivityHandler implements Route {
   /**
    * This handle method needs to be filled by any class implementing Route. When the path set in
@@ -72,7 +72,7 @@ public class ActivityHandler implements Route {
     // on participant number?
     HttpRequest buildBoredApiRequest =
         HttpRequest.newBuilder()
-            .uri(new URI("http://www.boredapi.com/api/activity/"))
+            .uri(new URI("https://bored-api.appbrewery.com/filter"))
             .GET()
             .build();
 

--- a/src/main/java/edu/brown/cs/student/main/server/Server.java
+++ b/src/main/java/edu/brown/cs/student/main/server/Server.java
@@ -46,8 +46,7 @@ public class Server {
           response.header("Access-Control-Allow-Methods", "*");
         });
 
-    // Sets up data needed for the OrderHandler. You will likely not read from local
-    // JSON in this sprint.
+    // Sets up data needed for the OrderHandler by reading from a local JSON.
     String menuAsJson = SoupAPIUtilities.readInJson("data/menu.json");
     List<Soup> menu = new ArrayList<>();
     try {


### PR DESCRIPTION
The current server-gearup direct students to use boredapi.com for sending API requests in the ActivityHandler.java class. However, it appears that boredapi.com is no longer supported or is failing. Instead, bored-api.appbrewery.com provides similar functionality.